### PR TITLE
fix: relative paths for images

### DIFF
--- a/client/src/components/login-reg-components/HeroImg.jsx
+++ b/client/src/components/login-reg-components/HeroImg.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import imgs from "/Users/Nicole/Desktop/projects/iSmile/client/src/static/static-imgs/jacqueline-munguia-1pAwJiCD60c-unsplash.jpg";
+import imgs from "../../static/static-imgs/jacqueline-munguia-1pAwJiCD60c-unsplash.jpg";
 
 export const HeroImg = () => {
   return (

--- a/client/src/components/login-reg-components/Landing.jsx
+++ b/client/src/components/login-reg-components/Landing.jsx
@@ -3,10 +3,10 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import "./login-reg-component-styles.css";
-import smile from "/Users/Nicole/Desktop/projects/iSmile/client/src/static/static-imgs/pexels-juan-pablo-serrano-arenas-967016.jpg";
-import green from "/Users/Nicole/Desktop/projects/iSmile/client/src/static/static-imgs/pexels-pixabay-208147.jpg";
-import stop from "/Users/Nicole/Desktop/projects/iSmile/client/src/static/static-imgs/pexels-pixabay-264196.jpg";
-import chhese from "/Users/Nicole/Desktop/projects/iSmile/client/src/static/static-imgs/pexels-pixabay-208147.jpg";
+import smile from "../../static/static-imgs/pexels-juan-pablo-serrano-arenas-967016.jpg";
+import green from "../../static/static-imgs/pexels-pixabay-208147.jpg";
+import stop from "../../static/static-imgs/pexels-pixabay-264196.jpg";
+import chhese from "../../static/static-imgs/pexels-pixabay-208147.jpg";
 import { Link } from "react-router-dom/cjs/react-router-dom.min";
 
 const Landing = (props) => {


### PR DESCRIPTION
@ngray122 The old paths were pointing to the full path of the image on your computer, instead of the path of the image inside the repository.

File paths need to be relative to the root of the project, because the `Users/Nicole/Desktop/projects/` route only lives on your local machine. Deploying this app with the old routes would not display any of the images because the app would be looking for folders that exist only on your computer.

Also random fyi:
Whenever you see an import path with any sort of "../../", it's a relative path.

Whenever you see a full import path, like your old paths below, they're absolute paths.